### PR TITLE
docs: removing Continuous Integration (CI) badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,4 @@
 # Programming Exercises
-[![Haskell Continuous Integration (CI)](https://github.com/DeveloperC286/programming_exercises/actions/workflows/haskell-continuous-integration.yml/badge.svg)](https://github.com/DeveloperC286/programming_exercises/actions/workflows/haskell-continuous-integration.yml)
-[![Rust Continuous Integration (CI)](https://github.com/DeveloperC286/programming_exercises/actions/workflows/rust-continuous-integration.yml/badge.svg)](https://github.com/DeveloperC286/programming_exercises/actions/workflows/rust-continuous-integration.yml)
-[![Lisp Continuous Integration (CI)](https://github.com/DeveloperC286/programming_exercises/actions/workflows/lisp-continuous-integration.yml/badge.svg)](https://github.com/DeveloperC286/programming_exercises/actions/workflows/lisp-continuous-integration.yml)
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
 [![License](https://img.shields.io/badge/License-AGPLv3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 


### PR DESCRIPTION
As the badge is for the latest workflow not the main branch.

We will also not block a release on checks, so need to run the CI workflow on the main branch. The checks are performed as part of the pull request.